### PR TITLE
Fix typo on DMG-KFDN-01

### DIFF
--- a/DMG-KFDN-01/DMG-KFDN-01.kicad_pcb
+++ b/DMG-KFDN-01/DMG-KFDN-01.kicad_pcb
@@ -1044,7 +1044,7 @@
   (gr_text "V1.0" (at 120.77192 70.95236) (layer "B.Mask") (tstamp 5edcefbe-9766-42c8-9529-28d0ec865573)
     (effects (font (size 1.5 1.5) (thickness 0.3)) (justify mirror))
   )
-  (gr_text "DMG-KDFN-01" (at 154.94 70.5358) (layer "F.Mask") (tstamp 6e68f0cd-800e-4167-9553-71fc59da1eeb)
+  (gr_text "DMG-KFDN-01" (at 154.94 70.5358) (layer "F.Mask") (tstamp 6e68f0cd-800e-4167-9553-71fc59da1eeb)
     (effects (font (size 1.5 1.5) (thickness 0.3)))
   )
 


### PR DESCRIPTION
The board reads "KDFN" and this PR updates it to "KFDN" (I've made this typo multiple times myself while searching for gerber files for this board 😅).

Here's a screenshot of the updated mask; note the text in top-right corner:

<img width="969" alt="Screen Shot 2022-08-21 at 2 47 59 PM" src="https://user-images.githubusercontent.com/444629/185812254-61df25bd-0b0d-437e-8555-32713d54ccdc.png">

Huge thanks for sharing this!

(PS. My branch name and commit message mentions "silkscreen" but this is actually just part of the mask, whoops)