### PR TITLE
docs: Fix incorrect/missing  R9 designator

### DIFF
--- a/AGB-E05-01/README.md
+++ b/AGB-E05-01/README.md
@@ -8,7 +8,7 @@ Intended as a replacement for Games like Emerald
 | C1,C2,C3,C4 |                           100nF 0402                          |
 |          C5 |            4pF or 10pF 0402 (depends on the board)            |
 |    R1,R2,R3 |                          Unpopulated                          |
-|    R4,R5,R6 |                            10K 0402                           |
+|    R4,R5,R9 |                            10K 0402                           |
 |       R6,R7 |                           100K 0402                           |
 |          R8 |                            1K 0402                            |
 | R10         | 2K Resistor 0603 or 1uF Capacitor 0603 (depends on the board) |


### PR DESCRIPTION
R6 was listed twice, and R9 was missing. I believe that the second R6 was a typo. Confirmed with a multimeter that R9 was 10K.